### PR TITLE
fix: matching source/repo_name in the url

### DIFF
--- a/autoload/phabricator.vim
+++ b/autoload/phabricator.vim
@@ -39,7 +39,7 @@ function! s:diffusion_root_for_remote(url) abort
   for host in hosts
     let host_pattern .= '\|' . escape(split(host, '://')[-1], '.')
   endfor
-  let matcher = '^\%(https\=://\|git://\|git@\|ssh://code@\|ssh://git@\)\=\zs\('.host_pattern.'\)\%(:\d\{1,5}\)'
+  let matcher = '^\%(https\=://\|git://\|git@\|ssh://code@\|ssh://git@\)\=\zs\('.host_pattern.'\)\%(:\d\{1,5}\)\/source\/[a-z]\+'
   let base = matchstr(a:url, matcher)
   if !empty(base)
     " Remove the port component of the hostname.


### PR DESCRIPTION
Correctly includes the source/repo_name into the GBrowse url

**Before:**
```
https://phab.easypo.net/browse/master/file;master
```
**After:**
```
https://phab.easypo.net/source/repo_name/browse/master/file;master
```